### PR TITLE
Scoped package support

### DIFF
--- a/src/tasks/scaffold.js
+++ b/src/tasks/scaffold.js
@@ -38,7 +38,7 @@ const isWindows = /^win/.test(process.platform);
 const npmBinary = isWindows ? 'npm.cmd' : 'npm';
 
 const filterInput = input => String(input)
-  .replace(/[^A-z0-9_]/g, '')
+  .replace(/[^A-z0-9_@/]/g, '')
   .trim();
 
 const scaffolds = {
@@ -186,7 +186,7 @@ const scaffoldPackage = type => async ({logger, options, args}) => {
 
   const choices = force ? force : await inquirer.prompt([{
     name: 'name',
-    message: 'Enter name of package ([A-z0-9_])',
+    message: 'Enter name of package ([A-z0-9_@/])',
     default: defaultName,
     filter: filterInput,
     validate: input => {


### PR DESCRIPTION
Previously, creating a new package that follows the standard scoped schema of OS.js would fail. For example, `@osjs/test` would have come out as `osjstest`, which was obviously not the intent of the end user.

This commit introduces the ability to create scoped packages without needing to manually correct the generated `package.json` after the fact.